### PR TITLE
Fix spelling of RemoveUploadedImages folder when adding assets

### DIFF
--- a/RemoveUploadedImages/class.removeuploadedimages.plugin.php
+++ b/RemoveUploadedImages/class.removeuploadedimages.plugin.php
@@ -63,8 +63,8 @@ class RemoveUploadedImagesPlugin extends Gdn_Plugin {
     }
 
     public function DiscussionController_Render_Before($Sender) {
-        $Sender->AddJsFile('remove_functions.js', 'plugins/removeuploadedimages');
-        $Sender->AddCssFile('remove_css.css', 'plugins/removeuploadedimages');
+        $Sender->AddJsFile('remove_functions.js', 'plugins/RemoveUploadedImages');
+        $Sender->AddCssFile('remove_css.css', 'plugins/RemoveUploadedImages');
     }
 
     public function plugincontroller_removeupload_create($Sender, $Args) {


### PR DESCRIPTION
For case sensitive systems adding the resources failed folder was spelled all lower case.